### PR TITLE
add net8.0 target framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
     - name: Build
       run: dotnet build src --configuration Release
     - name: Configuration Tests
@@ -52,5 +56,13 @@ jobs:
         fail_ci_if_error: true
         files: /home/runner/work/pulse/pulse/test/coverage.net7.0.opencover.xml
         name: net7-code-coverage
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
+    - name: Upload net8 Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true
+        files: /home/runner/work/pulse/pulse/test/coverage.net8.0.opencover.xml
+        name: net8-code-coverage
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,6 @@ jobs:
       run: dotnet build src --configuration Release
     - name: Configuration Tests
       run: dotnet test test --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-    - name: Upload net5 Code Coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
-        files: /home/runner/work/pulse/pulse/test/coverage.net5.0.opencover.xml
-        name: net5-code-coverage
-        token: ${{ secrets.CODECOV_TOKEN }}
-        verbose: true
     - name: Upload net6 Code Coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 5.0.x
     - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -13,10 +13,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 5.0.x
     - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -25,6 +25,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
     - name: Build
       run: dotnet build src --configuration Release /p:Version=${VERSION}
     - name: Pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
     - name: Build
       run: dotnet build src --configuration Release /p:Version=${VERSION}
     - name: Pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,6 @@ jobs:
         git branch --remote --contains | grep origin/main
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 5.0.x
     - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v3
       with:

--- a/src/Pulse.csproj
+++ b/src/Pulse.csproj
@@ -9,7 +9,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\common.ruleset</CodeAnalysisRuleSet>
     <IncludeSymbols>true</IncludeSymbols>
-    <Version>1.0.2</Version>
+    <Version>2.0.0</Version>
     <PackageId>pulse</PackageId>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/pulse</RepositoryUrl>

--- a/src/Pulse.csproj
+++ b/src/Pulse.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <Authors>dongrote;shinypancake</Authors>
     <AssemblyName>Pulse</AssemblyName>
     <RootNamespace>Pulse</RootNamespace>
@@ -9,7 +9,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\common.ruleset</CodeAnalysisRuleSet>
     <IncludeSymbols>true</IncludeSymbols>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageId>pulse</PackageId>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/pulse</RepositoryUrl>

--- a/src/Pulse.csproj
+++ b/src/Pulse.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Authors>dongrote;shinypancake</Authors>
     <AssemblyName>Pulse</AssemblyName>
     <RootNamespace>Pulse</RootNamespace>

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -24,6 +24,14 @@
         "resolved": "1.1.118",
         "contentHash": "Onx6ovGSqXSK07n/0eM3ZusiNdB6cIlJdabQhWGgJp3Vooy9AaLS/tigeybOJAobqbtggTamoWndz72JscZBvw=="
       }
+    },
+    "net8.0": {
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.1.118, )",
+        "resolved": "1.1.118",
+        "contentHash": "Onx6ovGSqXSK07n/0eM3ZusiNdB6cIlJdabQhWGgJp3Vooy9AaLS/tigeybOJAobqbtggTamoWndz72JscZBvw=="
+      }
     }
   }
 }

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -1,14 +1,6 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v5.0": {
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.1.118, )",
-        "resolved": "1.1.118",
-        "contentHash": "Onx6ovGSqXSK07n/0eM3ZusiNdB6cIlJdabQhWGgJp3Vooy9AaLS/tigeybOJAobqbtggTamoWndz72JscZBvw=="
-      }
-    },
     "net6.0": {
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/test/Pulse.UnitTests.csproj
+++ b/test/Pulse.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <Authors>dongrote;shinypancake</Authors>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Pulse.UnitTests.csproj
+++ b/test/Pulse.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Authors>dongrote;shinypancake</Authors>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Adds `net8.0` to the `TargetFrameworks`.

This bumps the major version number up to 2.0.0 as it removes support for `net5.0` which would break any `net5.0` projects depending on this package.